### PR TITLE
Using an older version of support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.7",
         "illuminate/foundation": "4.*",
         "illuminate/support": "4.*",
-        "pragmarx/support": "dev-master"
+        "pragmarx/support": "0.3.1"
     },
 
     "require-dev": {


### PR DESCRIPTION
The preRegister() method was renamed causing an undefined method error when using artisan to publish the configuration files.
